### PR TITLE
Update to latest Mongo Ruby Driver

### DIFF
--- a/lib/peek-mongo/version.rb
+++ b/lib/peek-mongo/version.rb
@@ -1,5 +1,5 @@
 module Peek
   module Mongo
-    VERSION = '2.1.0'
+    VERSION = '2.1.1'
   end
 end

--- a/lib/peek-mongo/version.rb
+++ b/lib/peek-mongo/version.rb
@@ -1,5 +1,5 @@
 module Peek
   module Mongo
-    VERSION = '1.1.0'
+    VERSION = '2.1.0'
   end
 end

--- a/peek-mongo.gemspec
+++ b/peek-mongo.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'peek'
-  gem.add_dependency 'mongo', '>= 1.8'
-  gem.add_dependency 'atomic', '>= 1.0.0'
+  gem.add_dependency 'mongo', '>= 2.4.1'
+  gem.add_dependency 'concurrent-ruby', '>= 1.0.4'
 end


### PR DESCRIPTION
Sorry if this repo is too old to consider a PR for.

This PR updates `peek-mongo` to handle timing through the new `Socket` class and counting through the `payload` method defined in the `Protocol` classes.  The new overall structure of the code is based off of `peek-redis`, defining overrides to the methods involved to count and time. 

`atomic` isn't used anymore, apparently it's outdated and according to the repo we should be using `concurrent-ruby` and their `Concurrent::AtomicFixnum`.

Again, sorry if this PR isn't acceptable due to the repo being years old. There just simply isn't a functioning peek-mongo for new versions. 